### PR TITLE
Removes Erlang version check, peg lhttpc to version.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,4 @@
-%% -*- erlang -*- 
-{require_otp_vsn, "(17|R16B0?[123])"}.
-
+%% -*- erlang -*-
 {cover_enabled, true}.
 {cover_print_enabled, true}.
 
@@ -24,7 +22,7 @@
 {deps,
  [
   {lhttpc, ".*",
-    {git, "git://github.com/ferd/lhttpc.git", "master"}},
+    {git, "git://github.com/ferd/lhttpc.git", {tag, "de7e48fb1045bbe522fa01f7c2c7839d89f04f88"}}},
   {jiffy, ".*",
     {git, "git://github.com/davisp/jiffy.git", {tag, "0.11.3"}}},
   {meck, ".*",
@@ -39,5 +37,3 @@
                deprecated_function_calls,
                deprecated_functions
               ]}.
-
-


### PR DESCRIPTION
Signed-off-by: Brian L. Troutwine <brian.troutwine@adroll.com>