### PR TITLE
Adjust some types & tests

### DIFF
--- a/include/kinetic.hrl
+++ b/include/kinetic.hrl
@@ -1,5 +1,5 @@
--ifndef(KINETIC_HRL). 
--define(KINETIC_HRL, true). 
+-ifndef(KINETIC_HRL).
+-define(KINETIC_HRL, true).
 
 -define(EXPIRATION_REFRESH, 120).
 -define(KINETIC_DATA, kinetic_data).
@@ -14,14 +14,14 @@
     access_key_id :: undefined | string(),
     secret_access_key :: undefined | string(),
     security_token :: undefined | string(),
-    expiration_seconds :: undefined | pos_integer()
+    expiration_seconds :: undefined | no_expire | pos_integer()
 }).
 
 
 -record(kinetic_arguments, {
     region :: undefined | string(),
     date :: undefined | string(),
-    host :: undefined | string(), 
+    host :: undefined | string(),
     url :: undefined | string(),
     lhttpc_opts = [] :: [any()],
     timeout :: undefined | pos_integer(),
@@ -34,8 +34,8 @@
         partitions_number=1000 :: pos_integer(),
         timeout=5000 :: pos_integer(),
         buffer= <<"">> :: binary(),
-        buffer_size=0 :: pos_integer(),
-        current_partition_num=0 :: pos_integer(),
+        buffer_size=0 :: non_neg_integer(),
+        current_partition_num=0 :: non_neg_integer(),
         flush_interval=1000 :: pos_integer(),
         flush_tref :: undefined | term(),
         retries=3 :: pos_integer()

--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
   {jiffy, ".*",
     {git, "git://github.com/davisp/jiffy.git", {tag, "0.11.3"}}},
   {meck, ".*",
-    {git, "git://github.com/eproxus/meck.git", {tag, "0.8.2"}}}
+    {git, "git://github.com/eproxus/meck.git", {tag, "0.8.3"}}}
  ]}.
 
 {xref_warnings, false}.

--- a/src/kinetic_stream_sup.erl
+++ b/src/kinetic_stream_sup.erl
@@ -7,18 +7,12 @@
 
 -include("kinetic.hrl").
 
--type child() :: {atom(), {atom(), atom(), list(any)},
-    atom(), integer(), atom(), list(atom())}.
-
--spec start_link() -> {ok, pid()} | {error, atom()}.
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, [[]]).
 
--spec init(any()) -> {ok, {{atom(), integer(), integer()}, [child()]}}.
 init(_) ->
     KineticStream = {kinetic_stream,
                      {kinetic_stream, start_link, []},
                      transient, 10000, worker, [kinetic_stream]},
 
     {ok, {{simple_one_for_one, 10, 1}, [KineticStream]}}.
-

--- a/src/kinetic_sup.erl
+++ b/src/kinetic_sup.erl
@@ -6,10 +6,6 @@
 
 -include("kinetic.hrl").
 
--type child() :: {atom(), {atom(), atom(), list(any)},
-    atom(), integer(), atom(), list(atom())}.
-
--spec start_link() -> {ok, pid()} | {error, atom()}.
 start_link() ->
     start_link([]).
 
@@ -22,7 +18,6 @@ start_link([]) ->
 start_link(Args) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, Args).
 
--spec init(any()) -> {ok, {{atom(), integer(), integer()}, [child()]}}.
 init(Opts) ->
     KineticConfig = {kinetic_config,
                      {kinetic_config, start_link, [Opts]},
@@ -42,4 +37,3 @@ stop(Pid) ->
         {'DOWN', MRef, process, _, _} ->
             ok
     end.
-

--- a/test/kinetic_config_tests.erl
+++ b/test/kinetic_config_tests.erl
@@ -56,8 +56,7 @@ kinetic_config_test_() ->
             fun test_teardown/1,
             [
                 ?_test(test_passed_metadata()),
-                ?_test(test_config_env()),
-                ?_test(test_error_init())
+                ?_test(test_config_env())
             ]
         }
     }.
@@ -102,10 +101,6 @@ test_config_env() ->
     value = kinetic_config:g(whatever),
     undefined = kinetic_config:g(something).
 
-test_error_init() ->
-    process_flag(trap_exit, true),
-    {error, {error, broken}} = kinetic_config:start_link([{metadata_base_url, "no_expire"}, {should_err, true}]),
-    process_flag(trap_exit, false).
 
 test_passed_metadata() ->
     {ok, _Pid} = kinetic_config:start_link([{aws_access_key_id, "whatever"},
@@ -154,6 +149,3 @@ test_update_data() ->
             expiration_seconds=64323799933},
         region="us-east-1",
         date=_Date3}} = kinetic_config:update_data([{metadata_base_url, "no_expire"}]).
-
-
-

--- a/test/kinetic_stream_tests.erl
+++ b/test/kinetic_stream_tests.erl
@@ -47,7 +47,7 @@ test_teardown(_) ->
     meck:unload(kinetic),
     meck:unload(supervisor).
 
-kinetic_config_test_() ->
+kinetic_stream_test_() ->
     {inorder,
         {foreach,
             fun test_setup/0,
@@ -165,4 +165,3 @@ wait_for_flush() ->
         1000 ->
             bad
     end.
-


### PR DESCRIPTION
- Use more recent version of meck.
- Correct type issues reported by dialyzer.
- Remove some unneeded specs/types.
- Correct a test generator name.
- Remove the `kinetic_config_tests:test_error_init` testcase; I don't know what this is testing.