### PR TITLE
Change put_records API to return resuls in order

### DIFF
--- a/src/kinetic.erl
+++ b/src/kinetic.erl
@@ -283,7 +283,6 @@ execute(Operation, Payload, Opts) ->
 
 
 record_status(Record) ->
-    io:format(user, "Record is ~p~n", [Record]),
     case lists:keymember(<<"SequenceNumber">>, 1, Record) of
         true -> ok;
         false -> {error, {get_value(<<"ErrorCode">>, Record),

--- a/test/kinetic_tests.erl
+++ b/test/kinetic_tests.erl
@@ -119,7 +119,6 @@ put_records_test_() ->
     }.
 
 test_put_records() ->
-    %% Test successful puts
     meck:expect(lhttpc, request, fun
         (_Url, post, _Headers, _Body, _Timeout, error) ->
                 {ok, {{400, bla}, headers, body}};
@@ -129,18 +128,6 @@ test_put_records() ->
                         [{\"SequenceNumber\": \"10\", \"ShardId\": \"5\" },
                          {\"ErrorCode\": \"404\", \"ErrorMessage\": \"Not found\"}]}">>}} end),
 
-    {ok, SuccessfulRecords, FailedRecords} = erlang:apply(kinetic, put_records, [[]]),
-    ?assertEqual([{<<"10">>, <<"5">>}], SuccessfulRecords),
-    ?assertEqual([{<<"404">>, <<"Not found">>}], FailedRecords),
-
-    %% test error on no successful puts
-    meck:expect(lhttpc, request, fun
-        (_Url, post, _Headers, _Body, _Timeout, error) ->
-                {ok, {{400, bla}, headers, body}};
-        (_Url, post, _Headers, _Body, _Timeout, _Opts) ->
-            {ok, {{200, bla}, headers, <<"{\"FailedRecordCount\": 1,
-                    \"Records\":
-                        [{\"ErrorCode\": \"404\", \"ErrorMessage\": \"Not found\"}]}">>}} end),
-
-    Expectedfailure = {error, {all_records_failed, [{<<"404">>, <<"Not found">>}]}},
-    ?assertEqual(Expectedfailure, erlang:apply(kinetic, put_records, [[]])).
+    {ok, [Result1, Result2]} = erlang:apply(kinetic, put_records, [[]]),
+    ?assertEqual(ok, Result1),
+    ?assertEqual({error, {<<"404">>, <<"Not found">>}}, Result2).


### PR DESCRIPTION
This changes the `put_records` API to be more faithful to the corresponding [Kinesis API](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html#API_PutRecords_ResponseSyntax), and return one result per input record, in order.

BTW, I'm getting a sporadic test failure that looks unrelated. Seems to pass / fail every other time.

```
    kinetic_stream_tests:58: kinetic_stream_test_...*failed*
in function kinetic_stream_tests:test_functionality/0 (test/kinetic_stream_tests.erl, line 130)
**error:{badmatch,false}
  output:<<"">>
```