### PR TITLE
Remove 'args' env key and just use app env keys.

### DIFF
--- a/development.config
+++ b/development.config
@@ -1,11 +1,12 @@
 %% -*- erlang -*-
-[{kinetic,
-    [%% All of these values are optional;
-     %% kinetic will get all of the context from the instance metadata service.
-     {metadata_base_url, "http://localhost:7001"},
-     {aws_access_key_id, "SOMEKEY"},
-     {aws_secret_access_key, "SOMESECRET"},
-     {iam_role, "kinetic"},
-     {lhttpc_opts, [{max_connections, 5000}]}
-    ]}]
-}].
+[
+ {kinetic, [
+            %% All of these values are optional;
+            %% kinetic will get all of the context from the instance metadata service.
+            {metadata_base_url, "http://localhost:7001"},
+            {aws_access_key_id, "SOMEKEY"},
+            {aws_secret_access_key, "SOMESECRET"},
+            {iam_role, "kinetic"},
+            {lhttpc_opts, [{max_connections, 5000}]}
+           ]}
+].

--- a/development.config
+++ b/development.config
@@ -1,14 +1,11 @@
 %% -*- erlang -*-
 [{kinetic,
-    [{args, [
-        % All of these values are optional
-        % kinetic will get all of the context from the instance
-        {metadata_base_url, "http://localhost:7001"},
-        {aws_access_key_id, "SOMEKEY"},
-        {aws_secret_access_key, "SOMESECRET"},
-        {iam_role, "kinetic"},
-
-        {lhttpc_opts, [{max_connections, 5000}]}
+    [%% All of these values are optional;
+     %% kinetic will get all of the context from the instance metadata service.
+     {metadata_base_url, "http://localhost:7001"},
+     {aws_access_key_id, "SOMEKEY"},
+     {aws_secret_access_key, "SOMESECRET"},
+     {iam_role, "kinetic"},
+     {lhttpc_opts, [{max_connections, 5000}]}
     ]}]
 }].
-

--- a/src/kinetic.app.src
+++ b/src/kinetic.app.src
@@ -5,6 +5,10 @@
   {modules, []},
   {registered, [kinetic_config]},
   {applications, [kernel, stdlib, inets, crypto, ssl, jiffy, lhttpc]},
-  {env, []},
-  {mod, {kinetic,[]}}
+  {mod, {kinetic_app, []}},
+  {env, [{metadata_base_url, undefined},
+         {aws_access_key_id, undefined},
+         {aws_secret_access_key, undefined},
+         {iam_role, undefined},
+         {lhttpc_opts, undefined}]}
  ]}.

--- a/src/kinetic.erl
+++ b/src/kinetic.erl
@@ -1,11 +1,6 @@
 -module(kinetic).
--behaviour(application).
-
 
 -export([start/0, stop/0]).
--export([start/2, stop/1]).
--export([start/1]).
-
 
 -export([create_stream/1, create_stream/2]).
 -export([list_streams/1, list_streams/2]).
@@ -20,29 +15,13 @@
 
 -include("kinetic.hrl").
 
-% application behaviour
 
--spec start() -> ok | {error, any()}.
 start() ->
     application:start(kinetic).
 
-
--spec stop() -> ok | {error, any()}.
 stop() ->
     application:stop(kinetic).
 
-
--spec start(normal | {takeover, node()} | {failover, node()}, any()) ->
-    {ok, pid()}.
-start(Opts) when is_list(Opts) ->
-    kinetic_sup:start_link(Opts).
-
-start(_, Opts) ->
-    kinetic_sup:start_link(Opts).
-
--spec stop(any()) -> ok.
-stop(_) ->
-    ok.
 
 % Public API
 

--- a/src/kinetic_app.erl
+++ b/src/kinetic_app.erl
@@ -1,0 +1,13 @@
+-module(kinetic_app).
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+
+start(_StartType, StartArgs) ->
+    kinetic_sup:start_link(StartArgs).
+
+
+stop(_State) ->
+    ok.

--- a/src/kinetic_sup.erl
+++ b/src/kinetic_sup.erl
@@ -6,17 +6,14 @@
 
 -include("kinetic.hrl").
 
+
 start_link() ->
     start_link([]).
 
 
-% Need the slightly stupid double code here to avoid an infinite loop
-% in case kinetic_config:g(args) -> []
-start_link([]) ->
-    Args = kinetic_config:g(args),
-    supervisor:start_link({local, ?MODULE}, ?MODULE, Args);
 start_link(Args) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, Args).
+
 
 init(Opts) ->
     KineticConfig = {kinetic_config,
@@ -29,7 +26,7 @@ init(Opts) ->
 
     {ok, {{one_for_one, 10, 1}, [KineticConfig, KineticStreamSup]}}.
 
--spec stop(pid()) -> ok.
+
 stop(Pid) ->
     MRef = erlang:monitor(process, Pid),
     exit(Pid, shutdown),


### PR DESCRIPTION
Remove use of `'args'` from app env.  Continue using args given to `kinetic_sup:start_link/1`, using values from app env if any are undefined, or default values if undefined/missing from app env.